### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ setup(
     # installed, specify them here.  If using Python 2.6 or less, then these
     # have to be included in MANIFEST.in as well.
     package_data={
-         'xicam': ['gui/*'],
+         'xicam': ['gui/*.*','gui/logos/*'],
     },
 
     # Although 'package_data' is the preferred approach, in some case you may


### PR DESCRIPTION
Fix installation error: `error: can't copy 'xicam/gui/logos': doesn't exist or not a regular file`